### PR TITLE
fix: correct status route metadata

### DIFF
--- a/Parking-Project/backend/src/routes/parking.js
+++ b/Parking-Project/backend/src/routes/parking.js
@@ -66,15 +66,15 @@ router.post('/refresh', async (req, res) => {
 // Health check - get cache statistics
 router.get('/status', async (req, res) => {
   try {
-    const result = await getAllParkingSpots();
-    
+    const { total, cached, lastUpdated } = await getAllParkingSpots();
+
     res.json({
       success: true,
       status: 'healthy',
       data: {
-        totalSpots: result.data.length,
-        cached: result.fromCache,
-        lastUpdate: result.lastUpdate,
+        totalSpots: total,
+        cached,
+        lastUpdate: lastUpdated,
         timestamp: new Date().toISOString()
       }
     });


### PR DESCRIPTION
## Summary
- ensure parking status endpoint uses correct metadata fields

## Testing
- `npx eslint backend/src/routes/parking.js`
- `npm run lint` *(fails: 'process' is not defined in backend/src/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_689578eaffe08331a16f5c581d6bac53