### PR TITLE
feat: add dashboard metrics via PostgreSQL

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "morgan": "^1.10.0",
     "dotenv": "^16.3.1",
     "node-cron": "^3.0.3",
-    "compression": "^1.7.4"
+    "compression": "^1.7.4",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import { getDashboardMetrics } from '../services/dashboardService.js';
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  try {
+    const data = await getDashboardMetrics();
+    res.json({ success: true, data });
+  } catch (err) {
+    console.error('Failed to fetch dashboard metrics', err);
+    res.status(500).json({ success: false, error: 'Failed to fetch dashboard metrics' });
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,4 +1,6 @@
 // backend/src/server.js
+/* eslint-env node */
+/* global process */
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -11,6 +13,7 @@ import { fileURLToPath } from 'url';
 // Routes
 import parkingRoutes from './routes/parking.js';
 import parkingInfoRoutes from './routes/parkingInfo.js';
+import dashboardRoutes from './routes/dashboard.js';
 
 // Services
 import { startParkingDataSync } from './services/parkingSync.js';
@@ -95,6 +98,7 @@ app.get('/api', (_req, res) => {
       health: '/health',
       parking: '/api/parking',
       parkingInfo: '/api/parking-info',
+      dashboard: '/api/dashboard',
     },
     timestamp: new Date().toISOString(),
   });
@@ -132,6 +136,7 @@ app.use('/api', cors(corsOptions));
 /* ---------- API routes ---------- */
 app.use('/api/parking', parkingRoutes);
 app.use('/api/parking-info', parkingInfoRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 /* ---------- 404 for API only ---------- */
 app.use('/api/*', (req, res) => {
@@ -150,6 +155,7 @@ app.get('*', (_req, res) => {
 });
 
 /* ---------- Global error handler ---------- */
+/* eslint-disable-next-line no-unused-vars */
 app.use((err, _req, res, _next) => {
   console.error('❌ API error:', err);
   const status = err.status || err.statusCode || 500;

--- a/backend/src/services/dashboardService.js
+++ b/backend/src/services/dashboardService.js
@@ -1,0 +1,14 @@
+import pool from '../utils/db.js';
+
+export async function getDashboardMetrics() {
+  const { rows } = await pool.query(
+    `SELECT population_growth, vehicle_change, vehicle_density_change FROM dashboard_metrics LIMIT 1`
+  );
+
+  const row = rows[0] || {};
+  return {
+    populationGrowth: row.population_growth ?? null,
+    vehicleChange: row.vehicle_change ?? null,
+    vehicleDensityChange: row.vehicle_density_change ?? null,
+  };
+}

--- a/backend/src/utils/db.js
+++ b/backend/src/utils/db.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+/* global process */
+import pg from 'pg';
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+});
+
+export default pool;

--- a/src/components/DashboardView.vue
+++ b/src/components/DashboardView.vue
@@ -13,15 +13,15 @@
     <section class="panel summary">
       <div class="summary-metrics">
         <div class="metric">
-          <div class="metric-value positive">+3.3%</div>
+          <div class="metric-value positive">{{ formatPercent(dashboardData?.populationGrowth) }}</div>
           <div class="metric-label">Net Population Growth</div>
         </div>
         <div class="metric">
-          <div class="metric-value negative">-9.9%</div>
+          <div class="metric-value negative">{{ formatPercent(dashboardData?.vehicleChange) }}</div>
           <div class="metric-label">Vehicle Change</div>
         </div>
         <div class="metric">
-          <div class="metric-value negative">-12.6%</div>
+          <div class="metric-value negative">{{ formatPercent(dashboardData?.vehicleDensityChange) }}</div>
           <div class="metric-label">Vehicle Density Change</div>
         </div>
       </div>
@@ -194,7 +194,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -235,6 +235,23 @@ const vehicleData = ref([
   { year: 2020, count: 215728 },
   { year: 2021, count: 188855 }
 ])
+
+const dashboardData = ref(null)
+
+const formatPercent = (n) => {
+  if (typeof n !== 'number') return '0%'
+  return `${n >= 0 ? '+' : ''}${n}%`
+}
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/dashboard')
+    const json = await res.json()
+    dashboardData.value = json.data
+  } catch (e) {
+    console.error('Failed to load dashboard data', e)
+  }
+})
 
 // Helper to format thousands with commas
 const fmt = (n) => new Intl.NumberFormat('en-AU').format(n)


### PR DESCRIPTION
## Summary
- connect backend to PostgreSQL using pg
- add dashboard service and route returning metrics
- load dashboard metrics from API in DashboardView

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint backend/src/utils/db.js backend/src/services/dashboardService.js backend/src/routes/dashboard.js backend/src/server.js src/components/DashboardView.vue && echo 'eslint ok'`


------
https://chatgpt.com/codex/tasks/task_e_689aa2ab560883318140b63a65144b24